### PR TITLE
adding flags to disable features not supported by 'GTX 1650 Ti with M…

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cfsmp3/gonvml v0.0.0-20190828220739-9ebdce4bb989 h1:yERlgatNHz1DICCSbpndUoBwtQX8haKGQaW0X3rbyT4=
 github.com/cfsmp3/gonvml v0.0.0-20190828220739-9ebdce4bb989/go.mod h1:mHePyfjLFeCKiqdBbfcp6EsZ8DuiqmyErsxO9r/H9FQ=
+github.com/cfsmp3/gonvml v0.0.6 h1:NA4Ac44F8SMHLhDh+wnjmut1wG3sep+kCQSdwJ+msYo=
+github.com/cfsmp3/gonvml v0.0.6/go.mod h1:mHePyfjLFeCKiqdBbfcp6EsZ8DuiqmyErsxO9r/H9FQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=


### PR DESCRIPTION
…ax-Q Design'

Hi, I am using the exporter on my Laptop, which has the GTX1650 Ti installed. It kept spamming my syslog with
```
2021/12/17 15:16:28 AveragePowerUsage() error: NVML: Not Found
2021/12/17 15:16:28 PowerLimitConstraints() error: NVML: Not Supported
2021/12/17 15:16:28 PowerLimits() error: NVML: Not Supported
NVML: Not Supported
2021/12/17 15:16:28 PowerManagementDefaultLimit() error: NVML: Not Supported
```

The implementation is copy-paste from `-enable-fanspeed`

I've opened the PR here, because the [aur repo](https://aur.archlinux.org/packages/prometheus-nvidia-gpu-exporter/) is based on it.

Cheers,
Marcus